### PR TITLE
Adding TextEdit from backbone to Applications

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "apps-projectcenter"]
 	path = apps-projectcenter
 	url = https://github.com/gnustep/apps-projectcenter
+[submodule "backbone"]
+	path = backbone
+	url = https://git.savannah.nongnu.org/git/backbone.git

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ install: check_root
 	cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
+	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
 	cd $$WORKDIR && tar -cJvf applications.txz /Applications /Library; \
 	fi;
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ install: check_root
 	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
+	cd $$WORKDIR/backbone/system ./bootstrap && ./configure ; \
+	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
+	cd $$WORKDIR/backbone/System/Applications/TextEdit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR && tar -cJvf applications.txz /Applications /Library; \
 	fi;
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install: check_root
 	cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/backbone/System && gmake clean; \
+	cd $$WORKDIR/backbone && git reset --hard; \
 	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
 	cd $$WORKDIR/backbone/System ./bootstrap && ./configure ; \
 	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install: check_root
 	cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/backbone/system && gmake clean; \
+	cd $$WORKDIR/backbone/System && gmake clean; \
 	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
 	cd $$WORKDIR/backbone/System ./bootstrap && ./configure ; \
 	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \

--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,30 @@ TARGET_DIR := /Applications
 
 # Define the install target
 install: check_root
-	@if [ -d "/Applications" ]; then \
+	@if [ -d "$(TARGET_DIR)" ]; then \
 	  echo "System appears to be already installed."; \
 	  exit 0; \
 	else \
-	if [ -d "/__w/applications/applications/" ]; then \
-	  WORKDIR="/__w/applications/applications/"; \
-	elif [ -d "/home/runner/work/applications/applications/" ]; then \
-	  WORKDIR="/home/runner/work/applications/applications/"; \
-	else \
-	  WORKDIR=`pwd`; \
-	fi; \
-	. /System/Makefiles/GNUstep.sh; \
-	CPUS=`nproc`; \
-	echo "CPUS is set to: to: $$WORKDIR"; \
-	cd $$WORKDIR/gap/ported-apps/Games/Chess && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
-	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/backbone && git reset --hard; \
-	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
-	cd $$WORKDIR/backbone/System ./bootstrap && ./configure ; \
-	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/backbone/System/Applications/TextEdit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR && tar -cJvf applications.txz /Applications /Library; \
+	  if [ -d "/__w/applications/applications/" ]; then \
+	    WORKDIR="/__w/applications/applications/"; \
+	  elif [ -d "/home/runner/work/applications/applications/" ]; then \
+	    WORKDIR="/home/runner/work/applications/applications/"; \
+	  else \
+	    WORKDIR=$$(pwd); \
+	  fi; \
+	  . /System/Makefiles/GNUstep.sh; \
+	  CPUS=$$(nproc); \
+	  echo "WORKDIR is set to: $$WORKDIR"; \
+	  cd $$WORKDIR/gap/ported-apps/Games/Chess && gmake -j"$$CPUS" || exit 1 && gmake install; \
+	  cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"$$CPUS" || exit 1 && gmake install; \
+	  cd $$WORKDIR/apps-gorm && gmake -j"$$CPUS" || exit 1 && gmake install; \
+	  cd $$WORKDIR/apps-projectcenter && gmake -j"$$CPUS" || exit 1 && gmake install; \
+	  cd $$WORKDIR/backbone && git reset --hard; \
+	  cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
+	  cd $$WORKDIR/backbone/System && ./bootstrap && ./configure; \
+	  cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"$$CPUS" || exit 1 && gmake install; \
+	  cd $$WORKDIR/backbone/System/Applications/TextEdit && gmake -j"$$CPUS" || exit 1 && gmake install; \
+	  cd $$WORKDIR && tar -cJvf applications.txz /Applications /Library; \
 	fi;
 
 # Define the uninstall target
@@ -53,10 +53,10 @@ uninstall: check_root
 	fi; \
 	if [ -n "$$removed" ]; then \
 	  echo "Removed the following directories: $$removed"; \
-	  return 0; \
+	  exit 0; \
 	else \
 	  echo "No directories needed to be removed."; \
-	  return 1; \
+	  exit 1; \
 	fi
 
 clean: check_root

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install: check_root
 	cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
-	cd $$WORKDIR/backbone && gmake clean; \
+	cd $$WORKDIR/backbone/system && gmake clean; \
 	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
 	cd $$WORKDIR/backbone/system ./bootstrap && ./configure ; \
 	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ install: check_root
 	cd $$WORKDIR/gap/system-apps/Terminal && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-gorm && gmake -j"${CPUS}" || exit 1 && gmake install; \
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
+	cd $$WORKDIR/backbone && gmake clean; \
 	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
 	cd $$WORKDIR/backbone/system ./bootstrap && ./configure ; \
 	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install: check_root
 	cd $$WORKDIR/apps-projectcenter && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/backbone/system && gmake clean; \
 	cd $$WORKDIR && git apply --check backbone-unset-system.patch && git apply backbone-unset-system.patch; \
-	cd $$WORKDIR/backbone/system ./bootstrap && ./configure ; \
+	cd $$WORKDIR/backbone/System ./bootstrap && ./configure ; \
 	cd $$WORKDIR/backbone/System/Frameworks/BBAppKit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR/backbone/System/Applications/TextEdit && gmake -j"${CPUS}" || exit 1 || exit 1 && gmake install; \
 	cd $$WORKDIR && tar -cJvf applications.txz /Applications /Library; \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository automates the installation of Gershwin Applications.
 
 * [Gershwin System](https://github.com/gershwin-os/system.git)
 * autoconf (required for backone apps)
+* automate (required for backone apps)
 
 ## Applications Included
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository automates the installation of Gershwin Applications.
 
 * [Gershwin System](https://github.com/gershwin-os/system.git)
 * autoconf (required for backone apps)
-* automate (required for backone apps)
+* automake (required for backone apps)
 
 ## Applications Included
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository automates the installation of Gershwin Applications.
 
 ### Requirements
 
-[Gershwin System](https://github.com/gershwin-os/system.git)
+* [Gershwin System](https://github.com/gershwin-os/system.git)
+* autoconf (required for backone apps)
 
 ## Applications Included
 
@@ -12,6 +13,7 @@ This repository automates the installation of Gershwin Applications.
 - **gap**: Terminal
 - **apps-gorm**: Gorm - Interface Builder for GNUstep
 - **apps-projectcenter**: Project Center - Integrated Development Environment (IDE) for GNUstep
+- **textedit**: TextEdit - Text Editor from backbone
 
 ## Installation Paths (LOCAL domain)
 

--- a/backbone-unset-system.patch
+++ b/backbone-unset-system.patch
@@ -1,7 +1,7 @@
-diff --git a/System/Backbone.make.in b/System/Backbone.make.in
+diff --git a/backbone/System/Backbone.make.in b/backbone/System/Backbone.make.in
 index db38189..5ca3e22 100644
---- a/System/Backbone.make.in
-+++ b/System/Backbone.make.in
+--- a/backbone/System/Backbone.make.in
++++ b/backbone/System/Backbone.make.in
 @@ -1,5 +1,3 @@
 -export GNUSTEP_INSTALLATION_DOMAIN=SYSTEM
 -

--- a/backbone-unset-system.patch
+++ b/backbone-unset-system.patch
@@ -1,0 +1,10 @@
+diff --git a/System/Backbone.make.in b/System/Backbone.make.in
+index db38189..5ca3e22 100644
+--- a/System/Backbone.make.in
++++ b/System/Backbone.make.in
+@@ -1,5 +1,3 @@
+-export GNUSTEP_INSTALLATION_DOMAIN=SYSTEM
+-
+ BACKBONE_VERSION = @PACKAGE_VERSION@
+ BBFRAMEWORKS=@abs_top_srcdir@/Frameworks
+ 


### PR DESCRIPTION
* Confirmed this works on FreeBSD but autoconf and automake will need to be installed first as noted in README
* This clones submodule for backbone and then patches using git to remove System Domain so that TextEdit will install to /Applications
* After this is merged I will follow up with another PR in system to make TextEdit the default editor