### PR TITLE
Uninstall should not error if no dirs need cleaned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ uninstall: check_root
 	  return 0; \
 	else \
 	  echo "No directories needed to be removed."; \
-	  return 1; \
+	  return 0; \
 	fi
 
 clean: check_root


### PR DESCRIPTION
* This is needed to fix a problem building ISOs in a clean environment. 
* Without this change the ISO build will fail because /Applications is not present and make uninstall is sending return 1 instead of return 0.